### PR TITLE
upgrade version of servlet api (#66)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -656,8 +656,8 @@
 
       <dependency>
         <groupId>javax.servlet</groupId>
-        <artifactId>servlet-api</artifactId>
-        <version>2.5</version>
+        <artifactId>javax.servlet-api</artifactId>
+        <version>3.0.1</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Update version of Servlet API to the version used by Jetty.  Make this a "provided" dependency.