### PR TITLE
Fix typo in Makefile: grealpth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SRC_DIR = $(shell grealpath ../SlipStreamClient/client/src)
+SRC_DIR = $(shell realpath ../SlipStreamClient/client/src)
 
 install:
 	pip install -r requirements.txt


### PR DESCRIPTION
I think this is a typo, I could find a realpath command but not the "grealpath" as in the makefile...