### PR TITLE
Use only git CLI to get the current branch name

### DIFF
--- a/tools/updateSlipStreamRepos
+++ b/tools/updateSlipStreamRepos
@@ -80,7 +80,7 @@ fi
 
 
 git_branch(){
-  pecho $(git branch | grep \* | sed "s/\* \(.*\)/[\1] /")
+  pecho $(git rev-parse --abbrev-ref HEAD)
 }
 
 update_ss_repo(){


### PR DESCRIPTION
Just a minor improvement that I found here http://stackoverflow.com/questions/6245570/how-to-get-current-branch-name-in-git