### PR TITLE
Upgrade core.async from v0.2.371 to the latest v0.2.374

### DIFF
--- a/clojure-deps/src/main/resources/default-deps.edn
+++ b/clojure-deps/src/main/resources/default-deps.edn
@@ -77,7 +77,7 @@
  [org.clojure/data.json "0.2.6"]
  [org.clojure/java.classpath "0.2.3"]
  [org.clojure/java.jdbc "0.4.2"]
- [org.clojure/core.async "0.2.371"]
+ [org.clojure/core.async "0.2.374"]
  [org.hibernate/hibernate-entitymanager "4.3.9.Final"]
  [org.hibernate/hibernate-c3p0 "4.3.9.Final"]
  [org.hsqldb/hsqldb "2.3.3"]

--- a/clojure-deps/src/main/resources/default-deps.edn
+++ b/clojure-deps/src/main/resources/default-deps.edn
@@ -77,7 +77,7 @@
  [org.clojure/data.json "0.2.6"]
  [org.clojure/java.classpath "0.2.3"]
  [org.clojure/java.jdbc "0.4.2"]
- [org.clojure/core.async "0.2.374"]
+ [org.clojure/core.async "0.2.374" :excludes [[org.clojure/tools.reader]]]
  [org.hibernate/hibernate-entitymanager "4.3.9.Final"]
  [org.hibernate/hibernate-c3p0 "4.3.9.Final"]
  [org.hsqldb/hsqldb "2.3.3"]

--- a/pom.xml
+++ b/pom.xml
@@ -875,7 +875,13 @@
       <dependency>
         <groupId>org.clojure</groupId>
         <artifactId>core.async</artifactId>
-        <version>0.2.371</version>
+        <version>0.2.374</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.clojure</groupId>
+            <artifactId>tools.reader</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Connected to SlipStream/SlipstreamServer#532

It's used at least in jar-async SlipStream/SlipstreamServer. The exclusion was
required to prevent a compile error. See issue SlipStream/SlipstreamServer#532
for details.

Thanks to @st for the help.