### PR TITLE
update to kvlt 0.1.4; remove test-cljs workarounds

### DIFF
--- a/clojure-deps/src/main/resources/default-deps.edn
+++ b/clojure-deps/src/main/resources/default-deps.edn
@@ -62,9 +62,7 @@
  [com.taoensso/tower "3.1.0-beta5"]
  [com.taoensso/timbre "4.7.4"]
  [crisptrutski/boot-cljs-test "0.3.0" :scope "test"]
- [org.clojars.sixsq/boot-cljs-test "0.2.2-SNAPSHOT" :scope "test"] ;; non-canonical fork, move back to canonical version now
-
- [doo "0.1.7" :scope "test"] ;; will be added by boot-cljs-test anyway, control options here
+ [doo "0.1.7" :scope "test"] ;; added by boot-cljs-test; control options here
 
  [enlive "1.1.6"]
  [environ "1.1.0"]
@@ -73,7 +71,7 @@
  [http-kit "2.2.0"]
  
  [instaparse "1.4.3"]
- [io.nervous/kvlt "0.1.3-SNAPSHOT"
+ [io.nervous/kvlt "0.1.4"
   :exclusions [org.clojure/clojurescript]]
 
  [javax.mail/mail "1.4.7" :scope "compile"]


### PR DESCRIPTION
Connected to slipstream/SlipStreamClojureAPI#53. 