### PR TITLE
Upgrade boto to 2.46.1 to provide new regions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <stratuslab.version.rpm.api.externals>${stratuslab.version}</stratuslab.version.rpm.api.externals>
 
     <libcloud.version>0.18.0</libcloud.version>
-    <boto.version>2.38.0</boto.version>
+    <boto.version>2.46.1</boto.version>
 
     <metrics.version>3.1.0</metrics.version>
 


### PR DESCRIPTION
Starting from this version we will be able to use future regions
without having to upgrade boto.